### PR TITLE
Feat: Add Inventory counting line number and description

### DIFF
--- a/testdata/TestGetInventoryCountings.golden
+++ b/testdata/TestGetInventoryCountings.golden
@@ -9,7 +9,9 @@
       {
         "ItemCode": "i001",
         "WarehouseCode": "01",
-        "CountedQuantity": 0
+        "CountedQuantity": 0,
+        "LineNumber": 1,
+        "ItemDescription": "Item1"
       }
     ]
   },
@@ -23,7 +25,9 @@
       {
         "ItemCode": "i003",
         "WarehouseCode": "01",
-        "CountedQuantity": 5
+        "CountedQuantity": 5,
+        "LineNumber": 1,
+        "ItemDescription": "Item3"
       }
     ]
   },
@@ -37,7 +41,9 @@
       {
         "ItemCode": "i002",
         "WarehouseCode": "01",
-        "CountedQuantity": 0
+        "CountedQuantity": 0,
+        "LineNumber": 1,
+        "ItemDescription": "Item2"
       }
     ]
   }

--- a/testdata/TestGetItems.golden
+++ b/testdata/TestGetItems.golden
@@ -15,6 +15,11 @@
     "PurchaseUnitWidth": 0
   },
   {
+    "ItemCode": "i001",
+    "ItemName": "Item1",
+    "PurchaseUnitWidth": 0
+  },
+  {
     "ItemCode": "LM4029MC",
     "ItemName": "Barette mémoire",
     "PurchaseUnitWidth": 0
@@ -297,11 +302,6 @@
   {
     "ItemCode": "A00006",
     "ItemName": "Imprimante HP type 600 Series Inc",
-    "PurchaseUnitWidth": 0
-  },
-  {
-    "ItemCode": "i001",
-    "ItemName": "Item1",
     "PurchaseUnitWidth": 0
   },
   {

--- a/types.go
+++ b/types.go
@@ -110,6 +110,8 @@ type InventoryCountingLine struct {
 	ItemCode        string  `json:"ItemCode"`
 	WarehouseCode   string  `json:"WarehouseCode"`
 	CountedQuantity float64 `json:"CountedQuantity"`
+	LineNum         int     `json:"LineNumber,omitempty"`
+	ItemDescription string  `json:"ItemDescription,omitempty"`
 }
 
 type InventoryCounting struct {


### PR DESCRIPTION
# Add Line Number and Description to Inventory Counting Line

## Changes
- Enhanced `InventoryCountingLine` struct with two new fields:
  - `LineNum`: Track the line number in the inventory counting document
  - `ItemDescription`: Store the description of the counted item

## Purpose
These additions improve the functionality of inventory counting by:
- Providing a way to reference specific lines in an inventory counting document
- Including descriptive information about items being counted

## Technical Details
Added two new fields to the `InventoryCountingLine` struct: