### PR TITLE
fix: remove omitempty tag for `BaseLine`

### DIFF
--- a/types.go
+++ b/types.go
@@ -43,7 +43,7 @@ type PurchaseDeliveryNoteLine struct {
 	Price           float64 `json:",omitempty"`
 	BaseType        int     `json:",omitempty"`
 	BaseEntry       int     `json:",omitempty"`
-	BaseLine        int     `json:",omitempty"`
+	BaseLine        int
 }
 
 type (


### PR DESCRIPTION
closes #12